### PR TITLE
Added undefined variable old_image in get_dr_txt.py

### DIFF
--- a/get_dr_txt.py
+++ b/get_dr_txt.py
@@ -25,6 +25,7 @@ class mAP_FRCNN(FRCNN):
         self.confidence = 0.05
         f = open("./input/detection-results/"+image_id+".txt","w") 
         image_shape = np.array(np.shape(image)[0:2])
+        old_image = image
         old_width = image_shape[1]
         old_height = image_shape[0]
         width,height = get_new_img_size(old_width,old_height)


### PR DESCRIPTION
Hello, `faster-rcnn-pytorch/get_dr_txt.py:44:24: F821 undefined name 'old_image'`. Fixed in this PR.